### PR TITLE
Fix issue #27: search back button not working

### DIFF
--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -382,7 +382,7 @@ btnQuickInfoBack.addEventListener("click", function(){
   switchScreen("quick", "home");
 });
 
-let btnSearchBack = document.getElementById("btnSearchBack");
+let btnSearchBack = document.getElementById("search-back-btn");
 btnSearchBack.addEventListener("click", function(){
   switchScreen("search", "home");
 });


### PR DESCRIPTION
When naming convention was changed from camelCase to kebab-case, the ID for this listen event was not updated.